### PR TITLE
Add support for pnpm workspaces as single derivation

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -26,6 +26,7 @@ in
     , distDir ? "dist"
     , installInPlace ? false
     , installEnv ? { }
+    , buildEnv ? { }
     , noDevDependencies ? false
     , extraNodeModuleSources ? [ ]
     , copyPnpmStore ? true
@@ -68,6 +69,12 @@ in
           '';
 
           buildPhase = ''
+            ${concatStringsSep "\n" (
+              mapAttrsToList
+                (n: v: ''export ${n}="${v}"'')
+                buildEnv
+            )}
+
             runHook preBuild
 
             pnpm run ${script}
@@ -159,6 +166,6 @@ in
             };
 
         })
-        (attrs // { extraNodeModuleSources = null; installEnv = null; })
+        (attrs // { extraNodeModuleSources = null; installEnv = null; buildEnv = null;})
     );
 }


### PR DESCRIPTION
Allow a caller to specify a workspace and a list of components rather than a single source directory. This allows for the building of pnpm monorepo projects with dependency links between the various projects and a single pnpm-lock.yaml for the whole workspace. Requires that the script has the same name in all components.

The location of all of the per-component package.json files is overridable. A workspace project can still specify the location of the root package.json via packageJSON, as well as the components' package.json files via componentPackageJSONs. The list defaults to c/package.json for c in components.

Similarly, the list of distDirs for the components is overridable. For a workspace, the distDirs are all subdirs of $out rather than dist becoming $out. The default list is c/dist for c in components. Allowing for override handles the case where one component is built by a different tool like next and produces a different directory like ".next"

NB: Any "link:" dependencies will need to be recreated as a preBuild step. pnpm will create the symlinks during install, and nix removes them because when the node_modules derivation is built, they are dangling.

Attempts to leave the non-workspace pnpm package support intact.